### PR TITLE
Add Vercel configuration for static CRA deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": { "distDir": "build" }
+    }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a Vercel configuration to run the CRA build and serve the build directory
- route all paths to index.html so React Router works on Vercel

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69519e2612cc83329a4f89c7bdfd637c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets up Vercel for static CRA deployment and proper SPA routing.
> 
> - Adds `vercel.json` using `@vercel/static-build` with `distDir: build`
> - Adds catch-all route mapping `/(.*)` to `index.html` to support client-side routing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7cdbf8c1a0c981210228fdcbd540b64f6daf0097. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->