### PR TITLE
Add SSH portfolio landing page (minimal style)

### DIFF
--- a/src/Components/Navigation.js
+++ b/src/Components/Navigation.js
@@ -5,6 +5,7 @@ import { useDarkMode } from './DarkModeContext';
 const links = [
   { href: '/', label: 'Home' },
   { href: '/blog', label: 'Blogs' },
+  { href: '/ssh-portfolio', label: 'SSH' },
 ];
 
 const Navigation = () => {

--- a/src/Components/SlideTabs.js
+++ b/src/Components/SlideTabs.js
@@ -61,7 +61,8 @@ export const SlideTabs = () => {
         <Tab setPosition={setPosition} sectionId="about" isMobile={isMobile} isDarkMode={isDarkMode}>About</Tab>
         <Tab setPosition={setPosition} sectionId="experience" isMobile={isMobile} isDarkMode={isDarkMode}>{isMobile ? "Exp." : "Experience"}</Tab>
         <Tab setPosition={setPosition} sectionId="projects" isMobile={isMobile} isDarkMode={isDarkMode}>Projects</Tab>
-        <Tab setPosition={setPosition} sectionId="blogs" isMobile={isMobile} isDarkMode={isDarkMode} isBlogTab>Blogs</Tab>
+        <Tab setPosition={setPosition} sectionId="blogs" isMobile={isMobile} isDarkMode={isDarkMode} redirectTo="/blog">Blogs</Tab>
+        <Tab setPosition={setPosition} sectionId="ssh-portfolio" isMobile={isMobile} isDarkMode={isDarkMode} redirectTo="/ssh-portfolio">SSH</Tab>
         {!isMobile && (
           <Tab setPosition={setPosition} sectionId="contact" isMobile={isMobile} isDarkMode={isDarkMode}>Contact</Tab>
         )}
@@ -71,13 +72,13 @@ export const SlideTabs = () => {
   );
 };
 
-const Tab = ({ children, setPosition, sectionId, isMobile, isDarkMode, isBlogTab }) => {
+const Tab = ({ children, setPosition, sectionId, isMobile, isDarkMode, redirectTo }) => {
   const ref = useRef(null);
   const [isHovered, setIsHovered] = useState(false);
 
   const handleClick = () => {
-    if (isBlogTab) {
-      window.location.href = '/blog';
+    if (redirectTo) {
+      window.location.href = redirectTo;
       return;
     }
     const element = document.getElementById(sectionId);

--- a/src/Styles/ssh-portfolio.css
+++ b/src/Styles/ssh-portfolio.css
@@ -1,258 +1,98 @@
 .ssh-page {
   min-height: 100vh;
-  color: #d9ffe3;
-  background:
-    radial-gradient(circle at 8% 10%, rgba(46, 204, 113, 0.15), transparent 45%),
-    radial-gradient(circle at 92% 20%, rgba(52, 152, 219, 0.12), transparent 42%),
-    #07110b;
-}
-
-html.ssh-body,
-body.ssh-body {
-  background: #07110b !important;
-  min-height: 100%;
-  overflow-x: hidden;
-}
-
-html.ssh-body {
-  --blog-nav-bg: rgba(7, 17, 11, 0.85);
-  --blog-border: rgba(119, 255, 170, 0.12);
-  --blog-nav-link: rgba(190, 255, 214, 0.72);
-  --blog-nav-link-active: #b8ffca;
-  --blog-nav-toggle-bg: rgba(11, 29, 19, 0.85);
-  --blog-nav-toggle-border: rgba(119, 255, 170, 0.16);
-  --blog-nav-toggle-color: rgba(190, 255, 214, 0.78);
-  --blog-nav-toggle-hover: rgba(184, 255, 202, 0.55);
+  background-color: var(--background-color);
+  color: var(--text-color);
 }
 
 .ssh-main {
-  max-width: 1200px;
+  max-width: 760px;
   margin: 0 auto;
-  padding: 3.5rem 1.25rem 4rem;
+  padding: 5rem 1rem 4rem;
 }
 
-.ssh-hero-panel {
-  display: grid;
-  grid-template-columns: 1.05fr 0.95fr;
-  gap: 1.25rem;
-  align-items: stretch;
+.ssh-panel {
+  border: 1px solid var(--divider-color);
+  border-radius: 14px;
+  background-color: var(--card-bg);
+  padding: 2rem;
 }
 
-.ssh-terminal-shell,
-.ssh-content {
-  border: 1px solid rgba(119, 255, 170, 0.14);
-  border-radius: 20px;
-  background: rgba(6, 18, 11, 0.75);
-  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(6px);
-}
-
-.ssh-terminal-shell {
-  overflow: hidden;
-}
-
-.ssh-terminal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.9rem 1rem;
-  border-bottom: 1px solid rgba(119, 255, 170, 0.12);
-  background: rgba(7, 23, 14, 0.9);
-}
-
-.ssh-terminal-header p {
+.ssh-panel h1 {
   margin: 0;
-  color: rgba(217, 255, 227, 0.7);
-  font-size: 0.82rem;
-  letter-spacing: 0.03em;
-}
-
-.ssh-terminal-dots {
-  display: flex;
-  gap: 0.35rem;
-}
-
-.ssh-terminal-dots span {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  display: block;
-}
-
-.ssh-terminal-dots span:nth-child(1) { background: #ff5f57; }
-.ssh-terminal-dots span:nth-child(2) { background: #febc2e; }
-.ssh-terminal-dots span:nth-child(3) { background: #28c840; }
-
-.ssh-terminal-body {
-  padding: 1.15rem 1rem 1.25rem;
-  font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
-}
-
-.ssh-terminal-intro {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.9rem;
-  color: #b8ffca;
-  font-size: 0.9rem;
-}
-
-.ssh-line {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 0.45rem;
-  line-height: 1.4;
-}
-
-.ssh-prompt {
-  color: #7dffae;
-}
-
-.ssh-command {
-  color: #effff3;
-}
-
-.ssh-output {
-  margin-top: 1rem;
-  padding: 0.9rem;
-  border: 1px solid rgba(119, 255, 170, 0.12);
-  border-radius: 12px;
-  background: rgba(5, 14, 9, 0.6);
-}
-
-.ssh-output p {
-  margin: 0;
-  color: rgba(216, 255, 226, 0.85);
-}
-
-.ssh-output p + p {
-  margin-top: 0.6rem;
-}
-
-.ssh-content {
-  padding: 1.5rem;
-  display: flex;
-  flex-direction: column;
-}
-
-.ssh-eyebrow {
-  margin: 0 0 0.55rem;
-  color: rgba(125, 255, 174, 0.85);
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  font-size: 0.75rem;
-}
-
-.ssh-content h1 {
-  margin: 0;
-  color: #f0fff4;
-  line-height: 1.05;
-  font-size: clamp(2rem, 4vw, 3rem);
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  color: var(--text-color);
 }
 
 .ssh-description {
-  margin: 0.95rem 0 1rem;
-  color: rgba(217, 255, 227, 0.82);
-  font-size: 1rem;
-  line-height: 1.6;
+  margin: 0.8rem 0 1.25rem;
+  color: var(--text-color);
+  opacity: 0.8;
+  max-width: 38ch;
 }
 
 .ssh-command-card {
-  margin: 0.25rem 0 1.1rem;
-  padding: 0.95rem 1rem;
-  border-radius: 14px;
-  border: 1px solid rgba(119, 255, 170, 0.16);
-  background: rgba(3, 10, 7, 0.8);
+  margin: 0 0 1rem;
+  border: 1px solid var(--divider-color);
+  border-radius: 10px;
+  background-color: var(--background-color);
+  padding: 0.9rem 1rem;
 }
 
 .ssh-command-card code {
-  font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
-  font-size: clamp(1rem, 2.2vw, 1.1rem);
-  color: #c8ffd8;
+  font-family: Menlo, Consolas, monospace;
+  font-size: 1rem;
+  color: var(--text-color);
 }
 
-.ssh-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
-.ssh-action {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  border-radius: 999px;
+.ssh-copy-button {
   padding: 0.65rem 1rem;
-  text-decoration: none;
-  font: inherit;
+  border-radius: 10px;
+  border: 1px solid var(--text-color);
+  background-color: var(--text-color);
+  color: var(--background-color);
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  transition: opacity 0.2s ease;
 }
 
-.ssh-action:hover {
-  transform: translateY(-1px);
+.ssh-copy-button:hover {
+  opacity: 0.88;
 }
 
-.ssh-action-primary {
-  color: #031108;
-  background: #7dffae;
-  border: 1px solid #7dffae;
-  box-shadow: 0 10px 28px rgba(125, 255, 174, 0.22);
+.ssh-copy-button:focus-visible,
+.ssh-secondary-link a:focus-visible {
+  outline: 2px solid var(--text-color);
+  outline-offset: 3px;
 }
 
-.ssh-action-secondary {
-  color: #d7ffe2;
-  border: 1px solid rgba(119, 255, 170, 0.2);
-  background: rgba(8, 23, 15, 0.8);
-}
-
-.ssh-action-secondary:hover {
-  border-color: rgba(125, 255, 174, 0.38);
-}
-
-.ssh-feature-list {
+.ssh-secondary-link {
   margin: 1rem 0 0;
-  padding-left: 1.1rem;
-  color: rgba(217, 255, 227, 0.88);
-  line-height: 1.7;
+  font-size: 0.9rem;
 }
 
-.ssh-note {
-  margin: auto 0 0;
-  padding-top: 1rem;
-  color: rgba(191, 255, 214, 0.72);
-  font-size: 0.92rem;
+.ssh-secondary-link a {
+  color: var(--text-color);
+  opacity: 0.7;
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
-.ssh-note code {
-  color: #d7ffe2;
-  font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
-}
-
-@media (max-width: 900px) {
-  .ssh-hero-panel {
-    grid-template-columns: 1fr;
-  }
-
-  .ssh-main {
-    padding-top: 2rem;
-  }
+.ssh-secondary-link a:hover {
+  opacity: 1;
 }
 
 @media (max-width: 640px) {
   .ssh-main {
-    padding-inline: 0.85rem;
+    padding: 4.25rem 0.75rem 2.5rem;
   }
 
-  .ssh-content,
-  .ssh-terminal-body {
-    padding: 1rem;
+  .ssh-panel {
+    padding: 1.25rem;
   }
 
-  .ssh-terminal-header {
-    align-items: flex-start;
-    flex-direction: column;
+  .ssh-copy-button {
+    width: 100%;
   }
 }

--- a/src/Styles/ssh-portfolio.css
+++ b/src/Styles/ssh-portfolio.css
@@ -1,0 +1,258 @@
+.ssh-page {
+  min-height: 100vh;
+  color: #d9ffe3;
+  background:
+    radial-gradient(circle at 8% 10%, rgba(46, 204, 113, 0.15), transparent 45%),
+    radial-gradient(circle at 92% 20%, rgba(52, 152, 219, 0.12), transparent 42%),
+    #07110b;
+}
+
+html.ssh-body,
+body.ssh-body {
+  background: #07110b !important;
+  min-height: 100%;
+  overflow-x: hidden;
+}
+
+html.ssh-body {
+  --blog-nav-bg: rgba(7, 17, 11, 0.85);
+  --blog-border: rgba(119, 255, 170, 0.12);
+  --blog-nav-link: rgba(190, 255, 214, 0.72);
+  --blog-nav-link-active: #b8ffca;
+  --blog-nav-toggle-bg: rgba(11, 29, 19, 0.85);
+  --blog-nav-toggle-border: rgba(119, 255, 170, 0.16);
+  --blog-nav-toggle-color: rgba(190, 255, 214, 0.78);
+  --blog-nav-toggle-hover: rgba(184, 255, 202, 0.55);
+}
+
+.ssh-main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 3.5rem 1.25rem 4rem;
+}
+
+.ssh-hero-panel {
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 1.25rem;
+  align-items: stretch;
+}
+
+.ssh-terminal-shell,
+.ssh-content {
+  border: 1px solid rgba(119, 255, 170, 0.14);
+  border-radius: 20px;
+  background: rgba(6, 18, 11, 0.75);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(6px);
+}
+
+.ssh-terminal-shell {
+  overflow: hidden;
+}
+
+.ssh-terminal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.9rem 1rem;
+  border-bottom: 1px solid rgba(119, 255, 170, 0.12);
+  background: rgba(7, 23, 14, 0.9);
+}
+
+.ssh-terminal-header p {
+  margin: 0;
+  color: rgba(217, 255, 227, 0.7);
+  font-size: 0.82rem;
+  letter-spacing: 0.03em;
+}
+
+.ssh-terminal-dots {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.ssh-terminal-dots span {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: block;
+}
+
+.ssh-terminal-dots span:nth-child(1) { background: #ff5f57; }
+.ssh-terminal-dots span:nth-child(2) { background: #febc2e; }
+.ssh-terminal-dots span:nth-child(3) { background: #28c840; }
+
+.ssh-terminal-body {
+  padding: 1.15rem 1rem 1.25rem;
+  font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+}
+
+.ssh-terminal-intro {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.9rem;
+  color: #b8ffca;
+  font-size: 0.9rem;
+}
+
+.ssh-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.45rem;
+  line-height: 1.4;
+}
+
+.ssh-prompt {
+  color: #7dffae;
+}
+
+.ssh-command {
+  color: #effff3;
+}
+
+.ssh-output {
+  margin-top: 1rem;
+  padding: 0.9rem;
+  border: 1px solid rgba(119, 255, 170, 0.12);
+  border-radius: 12px;
+  background: rgba(5, 14, 9, 0.6);
+}
+
+.ssh-output p {
+  margin: 0;
+  color: rgba(216, 255, 226, 0.85);
+}
+
+.ssh-output p + p {
+  margin-top: 0.6rem;
+}
+
+.ssh-content {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.ssh-eyebrow {
+  margin: 0 0 0.55rem;
+  color: rgba(125, 255, 174, 0.85);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.75rem;
+}
+
+.ssh-content h1 {
+  margin: 0;
+  color: #f0fff4;
+  line-height: 1.05;
+  font-size: clamp(2rem, 4vw, 3rem);
+}
+
+.ssh-description {
+  margin: 0.95rem 0 1rem;
+  color: rgba(217, 255, 227, 0.82);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.ssh-command-card {
+  margin: 0.25rem 0 1.1rem;
+  padding: 0.95rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(119, 255, 170, 0.16);
+  background: rgba(3, 10, 7, 0.8);
+}
+
+.ssh-command-card code {
+  font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+  font-size: clamp(1rem, 2.2vw, 1.1rem);
+  color: #c8ffd8;
+}
+
+.ssh-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.ssh-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border-radius: 999px;
+  padding: 0.65rem 1rem;
+  text-decoration: none;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.ssh-action:hover {
+  transform: translateY(-1px);
+}
+
+.ssh-action-primary {
+  color: #031108;
+  background: #7dffae;
+  border: 1px solid #7dffae;
+  box-shadow: 0 10px 28px rgba(125, 255, 174, 0.22);
+}
+
+.ssh-action-secondary {
+  color: #d7ffe2;
+  border: 1px solid rgba(119, 255, 170, 0.2);
+  background: rgba(8, 23, 15, 0.8);
+}
+
+.ssh-action-secondary:hover {
+  border-color: rgba(125, 255, 174, 0.38);
+}
+
+.ssh-feature-list {
+  margin: 1rem 0 0;
+  padding-left: 1.1rem;
+  color: rgba(217, 255, 227, 0.88);
+  line-height: 1.7;
+}
+
+.ssh-note {
+  margin: auto 0 0;
+  padding-top: 1rem;
+  color: rgba(191, 255, 214, 0.72);
+  font-size: 0.92rem;
+}
+
+.ssh-note code {
+  color: #d7ffe2;
+  font-family: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+}
+
+@media (max-width: 900px) {
+  .ssh-hero-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .ssh-main {
+    padding-top: 2rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .ssh-main {
+    padding-inline: 0.85rem;
+  }
+
+  .ssh-content,
+  .ssh-terminal-body {
+    padding: 1rem;
+  }
+
+  .ssh-terminal-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/src/Styles/ssh-portfolio.css
+++ b/src/Styles/ssh-portfolio.css
@@ -27,7 +27,7 @@
   margin: 0.8rem 0 1.25rem;
   color: var(--text-color);
   opacity: 0.8;
-  max-width: 38ch;
+  white-space: nowrap;
 }
 
 .ssh-command-card {
@@ -86,10 +86,16 @@
 @media (max-width: 640px) {
   .ssh-main {
     padding: 4.25rem 0.75rem 2.5rem;
+    min-height: calc(100dvh - 72px);
   }
 
   .ssh-panel {
     padding: 1.25rem;
+    min-height: 68dvh;
+  }
+
+  .ssh-description {
+    white-space: normal;
   }
 
   .ssh-copy-button {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import App from './App';
 import Random from './Random';
 import Blog from './pages/Blog';
 import BlogPost from './pages/BlogPost';
+import SshPortfolio from './pages/SshPortfolio';
 import reportWebVitals from './reportWebVitals';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import 'bootstrap/dist/css/bootstrap.min.css';
@@ -26,6 +27,10 @@ const router = createBrowserRouter([
   {
     path: "/blog/:slug",
     element: <BlogPost />
+  },
+  {
+    path: "/ssh-portfolio",
+    element: <SshPortfolio />
   }
 ])
 

--- a/src/pages/SshPortfolio.js
+++ b/src/pages/SshPortfolio.js
@@ -1,0 +1,129 @@
+import { useEffect, useState } from 'react';
+import { ExternalLink, TerminalSquare } from 'lucide-react';
+import Navigation from '../Components/Navigation';
+import '../Styles/ssh-portfolio.css';
+
+const commandLines = [
+  { prompt: 'guest@joesluis.dev', command: 'ssh joesluis.dev' },
+  { prompt: 'ssh-portfolio', command: 'help' },
+  { prompt: 'ssh-portfolio', command: 'projects' },
+  { prompt: 'ssh-portfolio', command: 'about' },
+];
+
+const SshPortfolio = () => {
+  const [copyLabel, setCopyLabel] = useState('Copy SSH Command');
+
+  useEffect(() => {
+    document.title = 'SSH Portfolio | Johannes Sluis';
+  }, []);
+
+  useEffect(() => {
+    document.body.classList.add('ssh-body');
+    document.documentElement.classList.add('ssh-body');
+
+    return () => {
+      document.body.classList.remove('ssh-body');
+      document.documentElement.classList.remove('ssh-body');
+    };
+  }, []);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText('ssh joesluis.dev');
+      setCopyLabel('Copied');
+      window.setTimeout(() => setCopyLabel('Copy SSH Command'), 1600);
+    } catch (error) {
+      setCopyLabel('Copy failed');
+      window.setTimeout(() => setCopyLabel('Copy SSH Command'), 1600);
+    }
+  };
+
+  return (
+    <div className="ssh-page">
+      <Navigation />
+
+      <main className="ssh-main">
+        <section className="ssh-hero-panel" aria-labelledby="ssh-page-title">
+          <div className="ssh-terminal-shell">
+            <div className="ssh-terminal-header">
+              <div className="ssh-terminal-dots" aria-hidden="true">
+                <span />
+                <span />
+                <span />
+              </div>
+              <p>joesluis.dev :: interactive ssh portfolio</p>
+            </div>
+
+            <div className="ssh-terminal-body">
+              <div className="ssh-terminal-intro">
+                <TerminalSquare size={18} />
+                <span>Terminal Portfolio</span>
+              </div>
+
+              {commandLines.map((line) => (
+                <div key={`${line.prompt}-${line.command}`} className="ssh-line">
+                  <span className="ssh-prompt">{line.prompt}$</span>
+                  <span className="ssh-command">{line.command}</span>
+                </div>
+              ))}
+
+              <div className="ssh-output">
+                <p>
+                  I built a fully interactive SSH-based portfolio you can explore directly from your
+                  terminal.
+                </p>
+                <p>
+                  If you like command-line interfaces, this is the fun version of the site.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="ssh-content">
+            <p className="ssh-eyebrow">Hidden terminal mode</p>
+            <h1 id="ssh-page-title">Try the portfolio over SSH</h1>
+            <p className="ssh-description">
+              This website has a command-line twin. Connect with the command below to browse my work
+              in a terminal-first experience.
+            </p>
+
+            <div className="ssh-command-card" role="group" aria-label="SSH command">
+              <code>ssh joesluis.dev</code>
+            </div>
+
+            <div className="ssh-actions">
+              <button
+                type="button"
+                className="ssh-action ssh-action-primary"
+                onClick={handleCopy}
+                title="Copy: ssh joesluis.dev"
+              >
+                <TerminalSquare size={16} />
+                <span>{copyLabel}</span>
+              </button>
+              <a
+                className="ssh-action ssh-action-secondary"
+                href="/blog/ssh-portfolio-guide"
+              >
+                <ExternalLink size={16} />
+                <span>Read the build story</span>
+              </a>
+            </div>
+
+            <ul className="ssh-feature-list">
+              <li>Interactive command-driven navigation</li>
+              <li>Terminal-native way to explore projects and background</li>
+              <li>Fast, nerdy, and genuinely fun to demo</li>
+            </ul>
+
+            <p className="ssh-note">
+              Tip: open your local terminal and run <code>ssh joesluis.dev</code>.
+            </p>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default SshPortfolio;

--- a/src/pages/SshPortfolio.js
+++ b/src/pages/SshPortfolio.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import Navigation from '../Components/Navigation';
 import '../Styles/ssh-portfolio.css';
 
@@ -45,9 +46,9 @@ const SshPortfolio = () => {
           </button>
 
           <p className="ssh-secondary-link">
-            <a href="/blog/ssh-portfolio-guide">
+            <Link to="/blog/ssh-portfolio-guide">
               Read how I built it
-            </a>
+            </Link>
           </p>
         </section>
       </main>

--- a/src/pages/SshPortfolio.js
+++ b/src/pages/SshPortfolio.js
@@ -1,30 +1,12 @@
 import { useEffect, useState } from 'react';
-import { ExternalLink, TerminalSquare } from 'lucide-react';
 import Navigation from '../Components/Navigation';
 import '../Styles/ssh-portfolio.css';
-
-const commandLines = [
-  { prompt: 'guest@joesluis.dev', command: 'ssh joesluis.dev' },
-  { prompt: 'ssh-portfolio', command: 'help' },
-  { prompt: 'ssh-portfolio', command: 'projects' },
-  { prompt: 'ssh-portfolio', command: 'about' },
-];
 
 const SshPortfolio = () => {
   const [copyLabel, setCopyLabel] = useState('Copy SSH Command');
 
   useEffect(() => {
     document.title = 'SSH Portfolio | Johannes Sluis';
-  }, []);
-
-  useEffect(() => {
-    document.body.classList.add('ssh-body');
-    document.documentElement.classList.add('ssh-body');
-
-    return () => {
-      document.body.classList.remove('ssh-body');
-      document.documentElement.classList.remove('ssh-body');
-    };
   }, []);
 
   const handleCopy = async () => {
@@ -43,83 +25,30 @@ const SshPortfolio = () => {
       <Navigation />
 
       <main className="ssh-main">
-        <section className="ssh-hero-panel" aria-labelledby="ssh-page-title">
-          <div className="ssh-terminal-shell">
-            <div className="ssh-terminal-header">
-              <div className="ssh-terminal-dots" aria-hidden="true">
-                <span />
-                <span />
-                <span />
-              </div>
-              <p>joesluis.dev :: interactive ssh portfolio</p>
-            </div>
+        <section className="ssh-panel" aria-labelledby="ssh-page-title">
+          <h1 id="ssh-page-title">SSH Portfolio</h1>
+          <p className="ssh-description">
+            You can explore my portfolio directly in your terminal.
+          </p>
 
-            <div className="ssh-terminal-body">
-              <div className="ssh-terminal-intro">
-                <TerminalSquare size={18} />
-                <span>Terminal Portfolio</span>
-              </div>
-
-              {commandLines.map((line) => (
-                <div key={`${line.prompt}-${line.command}`} className="ssh-line">
-                  <span className="ssh-prompt">{line.prompt}$</span>
-                  <span className="ssh-command">{line.command}</span>
-                </div>
-              ))}
-
-              <div className="ssh-output">
-                <p>
-                  I built a fully interactive SSH-based portfolio you can explore directly from your
-                  terminal.
-                </p>
-                <p>
-                  If you like command-line interfaces, this is the fun version of the site.
-                </p>
-              </div>
-            </div>
+          <div className="ssh-command-card" role="group" aria-label="SSH command">
+            <code>ssh joesluis.dev</code>
           </div>
 
-          <div className="ssh-content">
-            <p className="ssh-eyebrow">Hidden terminal mode</p>
-            <h1 id="ssh-page-title">Try the portfolio over SSH</h1>
-            <p className="ssh-description">
-              This website has a command-line twin. Connect with the command below to browse my work
-              in a terminal-first experience.
-            </p>
+          <button
+            type="button"
+            className="ssh-copy-button"
+            onClick={handleCopy}
+            title="Copy: ssh joesluis.dev"
+          >
+            <span>{copyLabel}</span>
+          </button>
 
-            <div className="ssh-command-card" role="group" aria-label="SSH command">
-              <code>ssh joesluis.dev</code>
-            </div>
-
-            <div className="ssh-actions">
-              <button
-                type="button"
-                className="ssh-action ssh-action-primary"
-                onClick={handleCopy}
-                title="Copy: ssh joesluis.dev"
-              >
-                <TerminalSquare size={16} />
-                <span>{copyLabel}</span>
-              </button>
-              <a
-                className="ssh-action ssh-action-secondary"
-                href="/blog/ssh-portfolio-guide"
-              >
-                <ExternalLink size={16} />
-                <span>Read the build story</span>
-              </a>
-            </div>
-
-            <ul className="ssh-feature-list">
-              <li>Interactive command-driven navigation</li>
-              <li>Terminal-native way to explore projects and background</li>
-              <li>Fast, nerdy, and genuinely fun to demo</li>
-            </ul>
-
-            <p className="ssh-note">
-              Tip: open your local terminal and run <code>ssh joesluis.dev</code>.
-            </p>
-          </div>
+          <p className="ssh-secondary-link">
+            <a href="/blog/ssh-portfolio-guide">
+              Read how I built it
+            </a>
+          </p>
         </section>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- keep the `/ssh-portfolio` route and discovery links in nav/tabs
- redesign the SSH page to a minimal single-panel layout that matches the portfolio style
- reduce content to headline, one sentence, command display, copy button, and a low-emphasis build-story link
- remove neon terminal styling, gradients, decorative shell UI, and extra copy

## Testing
- npm run build

## Screenshots
- Not attached from this environment: no browser screenshot tooling is available here.
- I can add desktop/mobile screenshots after a manual capture pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/routing change that adds a new page and links; main functional addition is clipboard copy, which may behave differently across browsers/permissions but is isolated.
> 
> **Overview**
> Adds a new `SshPortfolio` landing page at `/ssh-portfolio` with minimal content: headline, SSH command display, a clipboard copy button with success/failure feedback, and a link to a related blog post.
> 
> Updates global navigation and `SlideTabs` to surface the new SSH destination, and generalizes tab click handling via a `redirectTo` prop (used for both `Blogs` and `SSH`). Includes new dedicated styles in `ssh-portfolio.css` to match the existing theme variables and responsive layout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 848a1aa77556a3f94f0303498b9bad37f1b050e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->